### PR TITLE
Declare throws IOException in Basic{Lexeme,Template}BundleParser constructors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>org.tendiwa</groupId>
             <artifactId>collections-utils</artifactId>
-            <version>0.1.0</version>
+            <version>0.2.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/org/tendiwa/inflectible/BasicLexemeBundleParser.java
+++ b/src/main/java/org/tendiwa/inflectible/BasicLexemeBundleParser.java
@@ -26,7 +26,6 @@ package org.tendiwa.inflectible;
 import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.apache.commons.io.IOUtils;
@@ -44,12 +43,13 @@ public final class BasicLexemeBundleParser extends LexemeBundleParser {
     /**
      * Ctor.
      * @param input Input stream with lexemes' markup
+     * @throws IOException If can't read in input stream
      */
-    public BasicLexemeBundleParser(final InputStream input) {
+    public BasicLexemeBundleParser(final InputStream input) throws IOException {
         super(
             new CommonTokenStream(
                 new LexemeBundleLexer(
-                    BasicLexemeBundleParser.createAntlrInputStream(input)
+                    new ANTLRInputStream(input)
                 )
             )
         );
@@ -58,27 +58,13 @@ public final class BasicLexemeBundleParser extends LexemeBundleParser {
     /**
      * Ctor.
      * @param markup Lexemes' markup
+     * @throws IOException If can't read the input stream
      */
-    public BasicLexemeBundleParser(final String... markup) {
+    public BasicLexemeBundleParser(final String... markup) throws IOException {
         this(
             IOUtils.toInputStream(
                 Joiner.on('\n').join(markup)
             )
         );
-    }
-
-    /**
-     * Creates an ANTLR input stream.
-     * @param input Input stream with lexemes' markup
-     * @return An ANTLR input stream with lexemes' characters
-     */
-    private static ANTLRInputStream createAntlrInputStream(
-        final InputStream input
-    ) {
-        try {
-            return new ANTLRInputStream(input);
-        } catch (final IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
     }
 }

--- a/src/main/java/org/tendiwa/inflectible/BasicTemplateBundleParser.java
+++ b/src/main/java/org/tendiwa/inflectible/BasicTemplateBundleParser.java
@@ -25,7 +25,6 @@ package org.tendiwa.inflectible;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.tendiwa.inflectible.antlr.TemplateBundleLexer;
@@ -42,30 +41,17 @@ public final class BasicTemplateBundleParser extends TemplateBundleParser {
     /**
      * Ctor.
      * @param input Input stream with templates' markup.
+     * @throws IOException If can't read the input stream
      */
-    public BasicTemplateBundleParser(final InputStream input) {
+    public BasicTemplateBundleParser(
+        final InputStream input
+    ) throws IOException {
         super(
             new CommonTokenStream(
                 new TemplateBundleLexer(
-                    createAntlrInputStream(input)
+                    new ANTLRInputStream(input)
                 )
             )
         );
     }
-
-    /**
-     * Creates an ANTLR input stream.
-     * @param input Input stream with templates' markup
-     * @return An ANTLR input stream with templates' characters
-     */
-    private static ANTLRInputStream createAntlrInputStream(
-        final InputStream input
-    ) {
-        try {
-            return new ANTLRInputStream(input);
-        } catch (final IOException ex) {
-            throw new UncheckedIOException(ex);
-        }
-    }
-
 }

--- a/src/main/java/org/tendiwa/inflectible/ParsedVocabulary.java
+++ b/src/main/java/org/tendiwa/inflectible/ParsedVocabulary.java
@@ -25,9 +25,11 @@ package org.tendiwa.inflectible;
 
 import com.google.common.collect.ForwardingMap;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import org.tenidwa.collections.utils.Rethrowing;
 
 /**
  * A vocabulary of lexemes that identifies each lexeme by a unique string.
@@ -57,11 +59,12 @@ public final class ParsedVocabulary extends ForwardingMap<String, Lexeme> {
      * Ctor.
      * @param grammemes Grammar of the language of the lexemes
      * @param sources Input streams with lexemes' markup
+     * @throws IOException If reading from any stream fails
      */
     public ParsedVocabulary(
         final Grammar grammemes,
         final List<InputStream> sources
-    ) {
+    ) throws IOException {
         super();
         this.input = sources;
         this.grammar = grammemes;
@@ -77,12 +80,13 @@ public final class ParsedVocabulary extends ForwardingMap<String, Lexeme> {
     /**
      * Constructs lexemes from markup.
      * @return Lexemes constructed from the markup in the input stream
+     * @throws IOException If reading from any stream fails
      */
-    private ImmutableMap<String, Lexeme> constructLexemes() {
+    private ImmutableMap<String, Lexeme> constructLexemes() throws IOException {
         return ImmutableMap.copyOf(
             this.input
                 .stream()
-                .map(BasicLexemeBundleParser::new)
+                .map(Rethrowing.rethrowFunction(BasicLexemeBundleParser::new))
                 .flatMap(parser -> parser.lexemes().lexeme().stream())
                 .collect(
                     java.util.stream.Collectors.toMap(

--- a/src/test/java/org/tendiwa/inflectible/BasicLexemeBundleParserTest.java
+++ b/src/test/java/org/tendiwa/inflectible/BasicLexemeBundleParserTest.java
@@ -25,7 +25,6 @@ package org.tendiwa.inflectible;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -41,7 +40,7 @@ public final class BasicLexemeBundleParserTest {
      * it throws {@link IOException}.
      * @throws Exception If fails
      */
-    @Test(expected = UncheckedIOException.class)
+    @Test(expected = IOException.class)
     public void failsWithBadInputStream() throws Exception {
         final InputStream failing = Mockito.mock(InputStream.class);
         Mockito.when(failing.read()).thenThrow(new IOException());

--- a/src/test/java/org/tendiwa/inflectible/BasicTemplateBundleParserTest.java
+++ b/src/test/java/org/tendiwa/inflectible/BasicTemplateBundleParserTest.java
@@ -25,7 +25,6 @@ package org.tendiwa.inflectible;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -41,7 +40,7 @@ public final class BasicTemplateBundleParserTest {
      * it throws {@link IOException}.
      * @throws Exception If fails
      */
-    @Test(expected = UncheckedIOException.class)
+    @Test(expected = IOException.class)
     public void failsWithBadInputStream() throws Exception {
         final InputStream failing = Mockito.mock(InputStream.class);
         Mockito.when(failing.read()).thenThrow(new IOException());

--- a/src/test/java/org/tendiwa/inflectible/ParsedLexemeTest.java
+++ b/src/test/java/org/tendiwa/inflectible/ParsedLexemeTest.java
@@ -24,6 +24,7 @@
 package org.tendiwa.inflectible;
 
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.util.stream.IntStream;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -123,11 +124,12 @@ public final class ParsedLexemeTest {
      * @param resource Name of a resource with lexemes' markup
      * @param index Index of a lexeme in the markup
      * @return Lexeme on {@code index}'th place in the markup
+     * @throws IOException If can't read the resource
      */
     private ParsedLexeme wordOfBundle(
         final String resource,
         final int index
-    ) {
+    ) throws IOException {
         return new ParsedLexeme(
             new English().grammar(),
             new BasicLexemeBundleParser(

--- a/src/test/java/org/tendiwa/inflectible/ParsedTwoPartVariableConceptPlaceholderTest.java
+++ b/src/test/java/org/tendiwa/inflectible/ParsedTwoPartVariableConceptPlaceholderTest.java
@@ -41,9 +41,10 @@ public final class ParsedTwoPartVariableConceptPlaceholderTest {
     /**
      * ParsedTwoPartVariableConceptPlaceholder can be constructed from an
      * ANTLR parse tree.
+     * @throws Exception If fails
      */
     @Test
-    public void constructsFromAntlrParseTree() {
+    public void constructsFromAntlrParseTree() throws Exception {
         MatcherAssert.assertThat(
             new ParsedTwoPartVariableConceptPlaceholder(
                 new English().grammar(),

--- a/src/test/java/org/tendiwa/inflectible/ParsedVocabularyTest.java
+++ b/src/test/java/org/tendiwa/inflectible/ParsedVocabularyTest.java
@@ -24,6 +24,7 @@
 package org.tendiwa.inflectible;
 
 import com.google.common.base.Joiner;
+import java.io.IOException;
 import java.util.Collections;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
@@ -59,8 +60,9 @@ public final class ParsedVocabularyTest {
     /**
      * Creates a small vocabulary for {@link English} language.
      * @return Vocabulary for {@link English}
+     * @throws IOException If can't read the vocabulary input stream
      */
-    private ParsedVocabulary englishVocabulary() {
+    private ParsedVocabulary englishVocabulary() throws IOException {
         return new ParsedVocabulary(
             new English().grammar(),
             Collections.singletonList(

--- a/src/test/java/org/tendiwa/inflectible/ParsedWordFormTest.java
+++ b/src/test/java/org/tendiwa/inflectible/ParsedWordFormTest.java
@@ -24,6 +24,7 @@
 package org.tendiwa.inflectible;
 
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
@@ -65,8 +66,9 @@ public final class ParsedWordFormTest {
     /**
      * Creates a plural word form <i>bears</i>.
      * @return Plural word form <i>bears</i>
+     * @throws IOException If can't read the vocabulary input stream
      */
-    private ParsedWordForm wordFormBears() {
+    private ParsedWordForm wordFormBears() throws IOException {
         return new ParsedWordForm(
             new English().grammar(),
             new BasicLexemeBundleParser(


### PR DESCRIPTION
In order to implement this, I had to introduce a little hacky facility from `org.tendiwa:collections-utils:0.2.0` to allow throwing checked exceptions.

Fixes #95