### PR TITLE
Fix escaped character sequences recognition

### DIFF
--- a/src/main/antlr4/org/tendiwa/inflectible/antlr/TemplateBundleLexer.g4
+++ b/src/main/antlr4/org/tendiwa/inflectible/antlr/TemplateBundleLexer.g4
@@ -27,11 +27,11 @@ TEMPLATE_NL: NL -> type(NL), skip;
 
 mode LINE_CONTENT;
 COMMENT: '//' SEA_CHAR* -> popMode;
-ESC: '\\[';
+ESC: '\\[' | '\\\\';
 PLACEHOLDER_START: '[' -> pushMode(PLACEHOLDER_ID);
 RAW_TEXT: SEA_CHAR+;
 LINE_CONTENT_NL: NL -> popMode, type(NL), skip;
-fragment SEA_CHAR: ~('\n' | '\r' | '[' | '}');
+fragment SEA_CHAR: ~('\n' | '\r' | '[' | '}' | '\\');
 
 mode PLACEHOLDER_ID;
 NO_GRAMMEME_PLACEHOLDER_END: ']' -> popMode;

--- a/src/main/java/org/tendiwa/inflectible/antlr/parsed/ParsedTemplate.java
+++ b/src/main/java/org/tendiwa/inflectible/antlr/parsed/ParsedTemplate.java
@@ -29,7 +29,6 @@ import org.tendiwa.inflectible.ArgumentName;
 import org.tendiwa.inflectible.BasicTemplate;
 import org.tendiwa.inflectible.Grammar;
 import org.tendiwa.inflectible.Lexeme;
-import org.tendiwa.inflectible.PiPlainText;
 import org.tendiwa.inflectible.Template;
 import org.tendiwa.inflectible.TemplateBodyPiece;
 import org.tendiwa.inflectible.Vocabulary;
@@ -138,7 +137,9 @@ final class ParsedTemplate implements Template {
         public void enterRawText(
             final TemplateBundleParser.RawTextContext context
         ) {
-            this.pieces.add(new PiPlainText(context.getText()));
+            this.pieces.add(
+                new PiParsedPlainText(context)
+            );
         }
 
         @Override

--- a/src/main/java/org/tendiwa/inflectible/antlr/parsed/PiParsedPlainText.java
+++ b/src/main/java/org/tendiwa/inflectible/antlr/parsed/PiParsedPlainText.java
@@ -1,0 +1,75 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Georgy Vlasov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tendiwa.inflectible.antlr.parsed;
+
+import org.tendiwa.inflectible.ActualArguments;
+import org.tendiwa.inflectible.PiPlainText;
+import org.tendiwa.inflectible.TemplateBodyPiece;
+import org.tendiwa.inflectible.Vocabulary;
+import org.tendiwa.inflectible.antlr.TemplateBundleParser;
+
+/**
+ * Plain text, probably with escaped characters, parsed from an ANTLR parse
+ * tree.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.2.0
+ */
+public final class PiParsedPlainText implements TemplateBodyPiece {
+    /**
+     * ANTLR parse tree of some plain text.
+     */
+    private final transient TemplateBundleParser.RawTextContext ctx;
+
+    /**
+     * Ctor.
+     * @param context ANTLR parse tree of some plain text.
+     */
+    public PiParsedPlainText(
+        final TemplateBundleParser.RawTextContext context
+    ) {
+        this.ctx = context;
+    }
+
+    @Override
+    public String fillUp(
+        final ActualArguments arguments,
+        final Vocabulary vocabulary
+    ) throws Exception {
+        return new PiPlainText(this.unescapedPlainText())
+            .fillUp(arguments, vocabulary);
+    }
+
+    /**
+     * Transforms text with escaped characters to the actual text that is
+     * implied by escaping.
+     * @return Plain text from the ANTLR parse tree, but without the backslash
+     *  escaping.
+     */
+    private String unescapedPlainText() {
+        return this.ctx.getText()
+            .replace("\\[", "[")
+            .replace("\\\\", "\\");
+    }
+}

--- a/src/test/java/org/tendiwa/inflectible/antlr/parsed/BasicTemplateBundleParserTest.java
+++ b/src/test/java/org/tendiwa/inflectible/antlr/parsed/BasicTemplateBundleParserTest.java
@@ -25,8 +25,11 @@ package org.tendiwa.inflectible.antlr.parsed;
 
 import java.io.IOException;
 import java.io.InputStream;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.tendiwa.inflectible.antlr.TemplateBundleLexer;
 
 /**
  * Unit tests for {@link BasicTemplateBundleParser}.
@@ -45,5 +48,30 @@ public final class BasicTemplateBundleParserTest {
         final InputStream failing = Mockito.mock(InputStream.class);
         Mockito.when(failing.read()).thenThrow(new IOException());
         new BasicTemplateBundleParser(failing);
+    }
+
+    /**
+     * {@link BasicTemplateBundleParser} can parse escaped characters from a
+     * stream.
+     * @throws Exception If fails
+     */
+    @Test
+    public void readsEscapedCharacters() throws Exception {
+        MatcherAssert.assertThat(
+            new BasicTemplateBundleParser(
+                "text.id() {",
+                "  Hello, \\[, this is \\\\",
+                "}"
+            )
+                .templates()
+                .template(0)
+                .templateBody()
+                .line(0)
+                .piece(0)
+                .rawText()
+                .getTokens(TemplateBundleLexer.ESC)
+                .size(),
+            CoreMatchers.equalTo(2)
+        );
     }
 }

--- a/src/test/java/org/tendiwa/inflectible/antlr/parsed/PiParsedPlainTextTest.java
+++ b/src/test/java/org/tendiwa/inflectible/antlr/parsed/PiParsedPlainTextTest.java
@@ -1,0 +1,97 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Georgy Vlasov
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.tendiwa.inflectible.antlr.parsed;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.tendiwa.inflectible.ActualArguments;
+import org.tendiwa.inflectible.Vocabulary;
+
+/**
+ * Unit tests for {@link PiParsedPlainText}.
+ * @author Georgy Vlasov (suseika@tendiwa.org)
+ * @version $Id$
+ * @since 0.2.0
+ */
+public final class PiParsedPlainTextTest {
+    /**
+     * {@link PiParsedPlainText} can obtain text from an ANTLR parse tree with
+     * plain text in it.
+     * @throws Exception If fails
+     */
+    @Test
+    public void parsesText() throws Exception {
+        MatcherAssert.assertThat(
+            new PiParsedPlainText(
+                new BasicTemplateBundleParser(
+                    "text.identifier() {",
+                    " Hello world",
+                    "} "
+                )
+                    .templates()
+                    .template(0)
+                    .templateBody()
+                    .line(0)
+                    .piece(0)
+                    .rawText()
+            )
+                .fillUp(
+                    Mockito.mock(ActualArguments.class),
+                    Mockito.mock(Vocabulary.class)
+                ),
+            CoreMatchers.equalTo("Hello world")
+        );
+    }
+
+    /**
+     * {@link PiParsedPlainText} can obtain text from an ANTLR parse tree
+     * that contains escaped characters.
+     * @throws Exception If fails
+     */
+    @Test
+    public void unescapesEscapeSequences() throws Exception {
+        MatcherAssert.assertThat(
+            new PiParsedPlainText(
+                new BasicTemplateBundleParser(
+                    "text.id() {",
+                    "  Hello \\[mom], backslashes: \\\\\\\\",
+                    "}"
+                )
+                    .templates()
+                    .template(0)
+                    .templateBody()
+                    .line(0)
+                    .piece(0)
+                    .rawText()
+            )
+                .fillUp(
+                    Mockito.mock(ActualArguments.class),
+                    Mockito.mock(Vocabulary.class)
+                ),
+            CoreMatchers.equalTo("Hello [mom], backslashes: \\\\")
+        );
+    }
+}


### PR DESCRIPTION
Created a parsed plaintext implementation of TemplateBodyPiece and tested that it turns escaped character sequences into unescaped characters.

Also had to fix the grammar a bit, because it was parsing escaped characters incorrectly. Added a test for grammar as well that tests if escaped characters are recognized as separate tokens.

Fixes #141