### PR TITLE
Reenable coverage check of RussianNounStem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
                             <exclude>org/tendiwa/inflectible/antlr/*</exclude>
                             <exclude>org/tendiwa/inflectible/FilledOutText.class</exclude>
                             <exclude>org/tendiwa/inflectible/inflection/GeneratedLexeme.class</exclude>
-                            <exclude>org/tendiwa/inflectible/implementations/RussianNounStem.class</exclude>
                             <exclude>org/tendiwa/inflectible/implementations/NotImplementedLexeme.class</exclude>
                             <exclude>org/tendiwa/inflectible/implementations/EnglishPartOfSpeech.class</exclude>
                         </excludes>


### PR DESCRIPTION
Coverage check was ignored because the class was too big and needed refactoring. It was refactored in #187, and now the coverage check can be reenabled.

Fixes #193 