### PR TITLE
Reenable coverage check for FilledOutText

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,6 @@
                     <instrumentation>
                         <excludes>
                             <exclude>org/tendiwa/inflectible/antlr/*</exclude>
-                            <exclude>org/tendiwa/inflectible/FilledOutText.class</exclude>
-                            <exclude>org/tendiwa/inflectible/implementations/EnglishPartOfSpeech.class</exclude>
                         </excludes>
                     </instrumentation>
                     <check>

--- a/src/test/java/org/tendiwa/inflectible/FilledOutTextTest.java
+++ b/src/test/java/org/tendiwa/inflectible/FilledOutTextTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 /**
@@ -46,11 +47,14 @@ public final class FilledOutTextTest {
         final String text = "Template";
         Mockito.when(template.fillUp(Mockito.any(), Mockito.any()))
             .thenReturn(text);
+        final Vocabulary vocabulary = Mockito.mock(Vocabulary.class);
+        Mockito.when(vocabulary.lexeme(Matchers.any()))
+            .thenReturn(new SingleFormLexeme("anything"));
         MatcherAssert.assertThat(
             new FilledOutText(
                 template,
-                Mockito.mock(Vocabulary.class),
-                ImmutableList.of()
+                vocabulary,
+                ImmutableList.of(() -> "DUDE", () -> "GAL")
             )
                 .string(),
             CoreMatchers.equalTo(text)


### PR DESCRIPTION
Improved test coverage and reenabled coverage check.

Fixes #196, #191